### PR TITLE
Fix for missing ASN1Decoder dependency on cocoapods and carthage

### DIFF
--- a/.changeset/rich-horses-matter.md
+++ b/.changeset/rich-horses-matter.md
@@ -1,0 +1,5 @@
+---
+"embedded-provision": patch
+---
+
+Fix for ASN1Decoder dependency missing from cocoapods and carthage

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "filom/ASN1Decoder" "1.9.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "filom/ASN1Decoder" "1.10.0"

--- a/EmbeddedProvision.podspec
+++ b/EmbeddedProvision.podspec
@@ -28,4 +28,6 @@ Pod::Spec.new do |s|
   s.swift_versions = ['5.3', '5.4', '5.5']
 
   s.source_files = 'Source/**/*.swift'
+
+  s.dependency "ASN1Decoder", "1.10.0"
 end


### PR DESCRIPTION
## Change description

Follow up to #4 

## Test Plan

Tested locally in a test app. Was broken when including the lib via cocoapods and carthage, but worked after adding the dependencies

## Type of Change

- [x] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->

## Guidelines

- [x] A [changeset] is included, or the change is not noteworthy enough to warrant one

<!-- links -->
[changeset]: ../CONTRIBUTING.md#changesets